### PR TITLE
using neuroc.deps::collapser to prevent duplicate DESCRIPTION tag bug

### DIFF
--- a/R/read_dcf.R
+++ b/R/read_dcf.R
@@ -4,6 +4,7 @@
 #' @param path path to the DESCRIPTION file
 #' @return List of the fields and the data.frame of the description information
 #' @export
+#' @importFrom neuroc.deps collapser
 #'
 read_dcf <- function(path = "DESCRIPTION") {
   file = file(path)
@@ -11,8 +12,8 @@ read_dcf <- function(path = "DESCRIPTION") {
     close(file)
   })
   fields <- colnames(read.dcf(file))
-  dcf = as.list(read.dcf(file,
-                         keep.white = fields, all = TRUE)[1, ])
+  dcf_file <- neuroc.deps::collapser(read.dcf(file, keep.white = fields, all = TRUE), cn = c("Imports", "Suggests", "Depends"))
+  dcf = as.list(dcf_file[1, ])
   return(list(fields = fields,
               dcf = dcf))
 }


### PR DESCRIPTION
Addressing the duplicate Suggests field bug (still showing up if a package has a DESCRIPTION file that points to older version of repos that had the duplicate Suggests field issue). 